### PR TITLE
isolate MCDF application to GPose

### DIFF
--- a/Ktisis/Data/Mcdf/McdfManager.cs
+++ b/Ktisis/Data/Mcdf/McdfManager.cs
@@ -20,7 +20,7 @@ namespace Ktisis.Data.Mcdf;
 public sealed class McdfManager : IDisposable {
 	private readonly IFramework _framework;
 	private readonly IpcManager _ipc;
-	private List<IGameObject> actors;
+	private List<IGameObject> actors = [];
 	
 
 	public McdfManager(
@@ -29,7 +29,6 @@ public sealed class McdfManager : IDisposable {
 	) {
 		this._framework = framework;
 		this._ipc = ipc;
-		this.actors = new();
 	}
 	
 	// MCDF loading
@@ -69,7 +68,7 @@ public sealed class McdfManager : IDisposable {
 			File.Delete(file);
 
 		// add actor to applied list
-		this.actors.add(actor);
+		this.actors.Add(actor);
 	}
 
 	private void ApplyCustomizeData(IGameObject actor, McdfData data) {

--- a/Ktisis/Interface/Editor/Context/SceneEntityMenuBuilder.cs
+++ b/Ktisis/Interface/Editor/Context/SceneEntityMenuBuilder.cs
@@ -74,7 +74,7 @@ public class SceneEntityMenuBuilder {
 	
 	// Actors
 
-	private void BuildActorMenu(ContextMenuBuilder menu, ActorEntity actor) {
+	private unsafe void BuildActorMenu(ContextMenuBuilder menu, ActorEntity actor) {
 		menu.Separator()
 			.Action("Target", actor.Actor.SetGPoseTarget)
 			.Separator()
@@ -85,7 +85,7 @@ public class SceneEntityMenuBuilder {
 				var builder = sub.Action("Character (.chara)", () => this.Ui.OpenCharaImport(actor))
 					.Action("Pose file (.pose)", () => this.Ui.OpenPoseImport(actor));
 				
-				if (this._ctx.Plugin.Ipc.IsAnyMcdfActive) {
+				if (this._ctx.Plugin.Ipc.IsAnyMcdfActive && actor.GetHuman() != null) {
 					builder.Action("Mare data (.mcdf)", () => {
 						this.Ui.OpenMcdfFile(path => this.ImportMcdf(actor, path));
 					});

--- a/Ktisis/Interop/Ipc/GlamourerIpcProvider.cs
+++ b/Ktisis/Interop/Ipc/GlamourerIpcProvider.cs
@@ -9,12 +9,14 @@ namespace Ktisis.Interop.Ipc;
 public class GlamourerIpcProvider {
 	private readonly ApplyState _applyState;
 	private readonly GetState _getState;
+	private readonly RevertState _revertState;
 	
 	public GlamourerIpcProvider(
 		IDalamudPluginInterface dpi
 	) {
 		this._applyState = new ApplyState(dpi);
 		this._getState = new GetState(dpi);
+		this._revertState = new RevertState(dpi);
 	}
 
 	public void ApplyState(string state, int index) {
@@ -23,5 +25,9 @@ public class GlamourerIpcProvider {
 
 	public void GetState(int index) {
 		this._getState.Invoke(index);
+	}
+
+	public void RevertState(int index) {
+		this._revertState.Invoke(index);
 	}
 }

--- a/Ktisis/Interop/Ipc/GlamourerIpcProvider.cs
+++ b/Ktisis/Interop/Ipc/GlamourerIpcProvider.cs
@@ -8,19 +8,27 @@ namespace Ktisis.Interop.Ipc;
 
 public class GlamourerIpcProvider {
 	private readonly ApplyState _applyState;
+	private readonly ApplyStateName _applyStateName;
 	private readonly GetState _getState;
 	private readonly RevertState _revertState;
+	private readonly RevertStateName _revertStateName;
 	
 	public GlamourerIpcProvider(
 		IDalamudPluginInterface dpi
 	) {
 		this._applyState = new ApplyState(dpi);
+		this._applyStateName = new ApplyStateName(dpi);
 		this._getState = new GetState(dpi);
 		this._revertState = new RevertState(dpi);
+		this._revertStateName = new RevertStateName(dpi);
 	}
 
 	public void ApplyState(string state, int index) {
 		this._applyState.Invoke(state, index);
+	}
+
+	public void ApplyStateName(string state, string playerName) {
+		this._applyStateName.Invoke(state, playerName);
 	}
 
 	public void GetState(int index) {
@@ -29,5 +37,9 @@ public class GlamourerIpcProvider {
 
 	public void RevertState(int index) {
 		this._revertState.Invoke(index);
+	}
+
+	public void RevertStateName(string playerName) {
+		this._revertStateName.Invoke(playerName);
 	}
 }

--- a/Ktisis/Interop/Ipc/GlamourerIpcProvider.cs
+++ b/Ktisis/Interop/Ipc/GlamourerIpcProvider.cs
@@ -8,14 +8,20 @@ namespace Ktisis.Interop.Ipc;
 
 public class GlamourerIpcProvider {
 	private readonly ApplyState _applyState;
+	private readonly GetState _getState;
 	
 	public GlamourerIpcProvider(
 		IDalamudPluginInterface dpi
 	) {
 		this._applyState = new ApplyState(dpi);
+		this._getState = new GetState(dpi);
 	}
 
 	public void ApplyState(string state, int index) {
 		this._applyState.Invoke(state, index);
+	}
+
+	public void GetState(int index) {
+		this._getState.Invoke(index);
 	}
 }


### PR DESCRIPTION
### Changes
- McdfManager.cs
  - adds Revert and RevertAll functionality to reset glamourer & c+ state for any applied actors
  - adds gpose event listener to trigger RevertAll on exit
    - Reverts to glamourer are called by actor Name, which should resolve issues of mcdfs lingering on overworld actors
  - tracks applied actors in a gpose session to revert appearance before applying a subsequent new mcdf (fixes advanced dye overlap issue https://discord.com/channels/975894364020686878/1410265982781489152)
- SceneEntityMenuBuilder.cs
  - blocks mcdf application onto non-human actors (users should spawn a new gpose actor and apply to them instead of minions or monsters)
- GlamourerIpcProvider.cs
  - adds RevertStateName
  - adds RevertState, ApplyStateName (unused outside of testing, can be removed)
  - adds GetState (unused, but could be valuable to save initial actor states pre-mcdf application if we want to revert to _that_ instead of game appearance)