### PR TITLE
reinstate main branch incognito mode

### DIFF
--- a/Ktisis/Common/Extensions/GameObjectEx.cs
+++ b/Ktisis/Common/Extensions/GameObjectEx.cs
@@ -11,11 +11,26 @@ using FFXIVClientStructs.FFXIV.Client.Graphics.Render;
 using FFXIVClientStructs.FFXIV.Client.Graphics.Scene;
 using CSGameObject = FFXIVClientStructs.FFXIV.Client.Game.Object.GameObject;
 
+using Ktisis.Editor.Context.Types;
+using Ktisis.Actions.Attributes;
+using Ktisis.Core;
+using Ktisis.Core.Types;
+using Ktisis.Core.Attributes;
+using Ktisis.Actions.Types;
+
 namespace Ktisis.Common.Extensions;
 
 public static class GameObjectEx {
-	public static string GetNameOrFallback(this IGameObject gameObject) {
+	public unsafe static string GetNameOrFallback(this IGameObject gameObject, bool incognito = false) {
+		// accepts Config.Editor.IncognitoPlayerNames to force censoring to Actor #XXX (if the actor is a PC)
+
+		var csPtr = (CSGameObject*)gameObject.Address;
 		var name = gameObject.Name.TextValue;
+
+		// force the fallback text if we're incognito and looking at a PC
+		if (incognito && csPtr != null && csPtr->GetObjectKind() == ObjectKind.Pc) {
+			return $"Actor #{gameObject.ObjectIndex}";
+		}
 		return !name.IsNullOrEmpty() ? name : $"Actor #{gameObject.ObjectIndex}";
 	}
 

--- a/Ktisis/Common/Extensions/GameObjectEx.cs
+++ b/Ktisis/Common/Extensions/GameObjectEx.cs
@@ -21,16 +21,21 @@ using Ktisis.Actions.Types;
 namespace Ktisis.Common.Extensions;
 
 public static class GameObjectEx {
+	public unsafe static bool IsPcCharacter(this IGameObject gameObject) {
+		var csPtr = (CSGameObject*)gameObject.Address;
+		return csPtr != null && csPtr->GetObjectKind() == ObjectKind.Pc;
+	}
+
 	public unsafe static string GetNameOrFallback(this IGameObject gameObject, bool incognito = false) {
 		// accepts Config.Editor.IncognitoPlayerNames to force censoring to Actor #XXX (if the actor is a PC)
 
-		var csPtr = (CSGameObject*)gameObject.Address;
-		var name = gameObject.Name.TextValue;
-
+		bool isPc = IsPcCharacter(gameObject);
 		// force the fallback text if we're incognito and looking at a PC
-		if (incognito && csPtr != null && csPtr->GetObjectKind() == ObjectKind.Pc) {
+		if (incognito && isPc) {
 			return $"Actor #{gameObject.ObjectIndex}";
 		}
+
+		var name = gameObject.Name.TextValue;
 		return !name.IsNullOrEmpty() ? name : $"Actor #{gameObject.ObjectIndex}";
 	}
 

--- a/Ktisis/Data/Config/Sections/EditorConfig.cs
+++ b/Ktisis/Data/Config/Sections/EditorConfig.cs
@@ -13,6 +13,8 @@ public class EditorConfig {
 
 	public bool ToggleEditorOnSelect = true;
 
+	public bool IncognitoPlayerNames = false;
+
 	public bool UseLegacyWindowBehavior = false;
 	public bool UseLegacyPoseViewTabs = false;
 	public bool UseLegacyLightEditor = false;

--- a/Ktisis/Interface/Editor/Popup/OverworldActorPopup.cs
+++ b/Ktisis/Interface/Editor/Popup/OverworldActorPopup.cs
@@ -47,6 +47,7 @@ public class OverworldActorPopup : KtisisPopup {
 		await module.AddFromOverworld(actor);
 	}
 	
-	private static bool DrawActorName(IGameObject actor, bool isFocus)
-		=> ImGui.Selectable(actor.GetNameOrFallback(), isFocus);
+	// TODO: this spams the call stack by getting a new name every frame
+	private bool DrawActorName(IGameObject actor, bool isFocus)
+		=> ImGui.Selectable(actor.GetNameOrFallback(this._ctx.Config.Editor.IncognitoPlayerNames), isFocus);
 }

--- a/Ktisis/Interface/Editor/Popup/OverworldActorPopup.cs
+++ b/Ktisis/Interface/Editor/Popup/OverworldActorPopup.cs
@@ -47,7 +47,7 @@ public class OverworldActorPopup : KtisisPopup {
 		await module.AddFromOverworld(actor);
 	}
 	
-	// TODO: this spams the call stack by getting a new name every frame
+	// TODO: runs every frame the popup is open
 	private bool DrawActorName(IGameObject actor, bool isFocus)
 		=> ImGui.Selectable(actor.GetNameOrFallback(this._ctx.Config.Editor.IncognitoPlayerNames), isFocus);
 }

--- a/Ktisis/Interface/Windows/ConfigWindow.cs
+++ b/Ktisis/Interface/Windows/ConfigWindow.cs
@@ -142,6 +142,10 @@ public class ConfigWindow : KtisisWindow {
 		
 		ImGui.Spacing();
 
+		ImGui.Checkbox(this.Locale.Translate("config.workspace.incognitoPlayerNames"), ref this.Config.Editor.IncognitoPlayerNames);
+
+		ImGui.Spacing();
+
 		ImGui.Checkbox(this.Locale.Translate("config.workspace.legacyWindows"), ref this.Config.Editor.UseLegacyWindowBehavior);
 		ImGui.Checkbox(this.Locale.Translate("config.workspace.legacyPoseTabs"), ref this.Config.Editor.UseLegacyPoseViewTabs);
 		ImGui.Checkbox(this.Locale.Translate("config.workspace.legacyLightEditor"), ref this.Config.Editor.UseLegacyLightEditor);

--- a/Ktisis/Localization/Data/en_US.json
+++ b/Ktisis/Localization/Data/en_US.json
@@ -256,6 +256,7 @@
 			"title": "Workspace",
 			"init": "Open workspace when entering GPose",
 			"editOnSelect": "Toggle object editor when selecting",
+			"incognitoPlayerNames": "Hide player names while in GPose (incognito mode)",
 			"legacyWindows": "Prefer legacy window behavior",
 			"legacyPoseTabs": "Prefer legacy pose view tabs",
 			"legacyLightEditor": "Prefer legacy light editor"

--- a/Ktisis/Scene/Factory/Builders/ActorBuilder.cs
+++ b/Ktisis/Scene/Factory/Builders/ActorBuilder.cs
@@ -18,7 +18,7 @@ public sealed class ActorBuilder : EntityBuilder<ActorEntity, IActorBuilder>, IA
 		IPoseBuilder pose,
 		IGameObject gameObject
 	) : base(scene) {
-		this.Name = gameObject.GetNameOrFallback();
+		this.Name = gameObject.GetNameOrFallback(scene.Context.Config.Editor.IncognitoPlayerNames);
 		this._pose = pose;
 		this._gameObject = gameObject;
 	}

--- a/Ktisis/Scene/Modules/GroupPoseModule.cs
+++ b/Ktisis/Scene/Modules/GroupPoseModule.cs
@@ -1,7 +1,9 @@
 using Dalamud.Utility.Signatures;
+using Dalamud.Hooking;
 
 using FFXIVClientStructs.FFXIV.Client.Game.Object;
 
+using Ktisis.Editor.Context.Types;
 using Ktisis.Interop.Hooking;
 using Ktisis.Scene.Entities.Game;
 using Ktisis.Scene.Types;
@@ -10,11 +12,19 @@ using Ktisis.Structs.GPose;
 namespace Ktisis.Scene.Modules;
 
 public class GroupPoseModule : SceneModule {
+	private readonly IEditorContext _ctx;
 	public GroupPoseModule(
 		IHookMediator hook,
-		ISceneManager scene
-	) : base(hook, scene) { }
-	
+		ISceneManager scene,
+		IEditorContext ctx
+	) : base(hook, scene) {
+		this._ctx = ctx;
+	 }
+
+	public override void Setup() {
+		this.EnableAll();
+	}
+
 	// GPose state wrappers
 
 	public unsafe GPoseState* GetGPoseState()
@@ -39,4 +49,18 @@ public class GroupPoseModule : SceneModule {
 	[Signature("E8 ?? ?? ?? ?? 0F B7 56 3C")]
 	private GetGPoseStateDelegate? _getGPoseState = null;
 	private unsafe delegate GPoseState* GetGPoseStateDelegate();
+
+	[Signature("E8 ?? ?? ?? ?? 48 8D 8D ?? ?? ?? ?? 48 83 C4 28", DetourName = nameof(UpdateGposeTarNameDetour))]
+	private Hook<UpdateGposeTarNameDelegate>? UpdateGposeTarNameHook = null;
+	private unsafe delegate void UpdateGposeTarNameDelegate(nint a1);
+	private unsafe void UpdateGposeTarNameDetour(nint a1) {
+		if (this._ctx.Config.Editor.IncognitoPlayerNames) {
+			// TODO: restrict renaming only to targeted _players_, not any actors
+			string nameToDisplay = "(Hidden by Ktisis)";
+			for (var i = 0; i < nameToDisplay.Length; i++)
+				*(char*)(a1 + 488 + i) = nameToDisplay[i];
+		}
+
+		this.UpdateGposeTarNameHook!.Original(a1);
+	}
 }

--- a/Ktisis/Scene/Modules/GroupPoseModule.cs
+++ b/Ktisis/Scene/Modules/GroupPoseModule.cs
@@ -12,14 +12,12 @@ using Ktisis.Structs.GPose;
 namespace Ktisis.Scene.Modules;
 
 public class GroupPoseModule : SceneModule {
-	private readonly IEditorContext _ctx;
+	private string NameToDisplay => "(Hidden by Ktisis)";
+
 	public GroupPoseModule(
 		IHookMediator hook,
-		ISceneManager scene,
-		IEditorContext ctx
-	) : base(hook, scene) {
-		this._ctx = ctx;
-	 }
+		ISceneManager scene
+	) : base(hook, scene) { }
 
 	public override void Setup() {
 		this.EnableAll();
@@ -54,11 +52,10 @@ public class GroupPoseModule : SceneModule {
 	private Hook<UpdateGposeTarNameDelegate>? UpdateGposeTarNameHook = null;
 	private unsafe delegate void UpdateGposeTarNameDelegate(nint a1);
 	private unsafe void UpdateGposeTarNameDetour(nint a1) {
-		if (this._ctx.Config.Editor.IncognitoPlayerNames) {
-			// TODO: restrict renaming only to targeted _players_, not any actors
-			string nameToDisplay = "(Hidden by Ktisis)";
-			for (var i = 0; i < nameToDisplay.Length; i++)
-				*(char*)(a1 + 488 + i) = nameToDisplay[i];
+		if (this.Scene.Context.Config.Editor.IncognitoPlayerNames) {
+			// TODO: restrict renaming only to targeted _players_, not all actors
+			for (var i = 0; i < this.NameToDisplay.Length; i++)
+				*(char*)(a1 + 488 + i) = this.NameToDisplay[i];
 		}
 
 		this.UpdateGposeTarNameHook!.Original(a1);

--- a/Ktisis/Scene/Modules/GroupPoseModule.cs
+++ b/Ktisis/Scene/Modules/GroupPoseModule.cs
@@ -1,13 +1,8 @@
-using System.Collections.Generic;
-using System.Linq;
-
 using Dalamud.Utility.Signatures;
 using Dalamud.Hooking;
-using Dalamud.Game;
 using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Plugin.Services;
 
-using FFXIVClientStructs.FFXIV.Client.Game.Object;
 using FFXIVClientStructs.FFXIV.Client.Game.Control;
 
 using Ktisis.Editor.Context.Types;

--- a/Ktisis/Scene/SceneManager.cs
+++ b/Ktisis/Scene/SceneManager.cs
@@ -44,7 +44,7 @@ public class SceneManager : SceneModuleContainer, ISceneManager {
 	}
 	
 	private void SetupModules() {
-		var gpose = this.AddModule<GroupPoseModule>();
+		var gpose = this.AddModule<GroupPoseModule>(this.Context);
 		this.AddModule<ActorModule>(gpose);
 		this.AddModule<LightModule>(gpose);
 		this.AddModule<EnvModule>();

--- a/Ktisis/Scene/SceneManager.cs
+++ b/Ktisis/Scene/SceneManager.cs
@@ -44,7 +44,7 @@ public class SceneManager : SceneModuleContainer, ISceneManager {
 	}
 	
 	private void SetupModules() {
-		var gpose = this.AddModule<GroupPoseModule>(this.Context);
+		var gpose = this.AddModule<GroupPoseModule>();
 		this.AddModule<ActorModule>(gpose);
 		this.AddModule<LightModule>(gpose);
 		this.AddModule<EnvModule>();


### PR DESCRIPTION
### changes
- GameObjectEx.cs
  - adds new helper fn `IsPcCharacter` which leans on the ObjectKind enum of a given gameobject
  - updates GetNameOrFallback (and its consumers) to accept an `incognito` bool - when provided, we check if the object in question is a PC and censor it via fallback if so
- EditorConfig.cs
  - adds config flag `IncognitoPlayerNames` and locale/ux for it
- GroupPoseModule.cs
  - reimplements TarNameHook [from main branch](https://github.com/ktisis-tools/Ktisis/blob/e37ce7acc97507a1bf22f8617827cf8e97825422/Ktisis/Interop/Hooks/GuiHooks.cs#L16)
  - the new hook evaluates the incognito config flag - if set, we pull whether a PC is targeted in gpose from the CS target service
  - if we're targeting any PC, replace the gpose window's name display with `Hidden by Ktisis`

### todo
- any other areas to censor?
- conditionally enable the hook instead of firing it every frame?
- cleaner way of identifying gpose target?

<img width="496" height="178" alt="image" src="https://github.com/user-attachments/assets/0123b7b7-bd00-4cac-b9b2-bcf8530aaf3f" />
<img width="590" height="292" alt="image" src="https://github.com/user-attachments/assets/d7534365-af81-4014-986b-28d440c14560" />
