### PR TITLE
reinstate work camera keybinds & sensitivity controls

### DIFF
--- a/Ktisis/Actions/Handlers/Camera/WorkcamBackAction.cs
+++ b/Ktisis/Actions/Handlers/Camera/WorkcamBackAction.cs
@@ -14,7 +14,7 @@ public class WorkcamBackAction(IPluginContext ctx) : KeyAction(ctx) {
 		Trigger = KeybindTrigger.OnDown,
 		Default = new ActionKeybind {
 			Enabled = true,
-			Combo = new KeyCombo(VirtualKey.NO_KEY)
+			Combo = new KeyCombo(VirtualKey.S)
 		}
 	};
 

--- a/Ktisis/Actions/Handlers/Camera/WorkcamBackAction.cs
+++ b/Ktisis/Actions/Handlers/Camera/WorkcamBackAction.cs
@@ -17,12 +17,7 @@ public class WorkcamBackAction(IPluginContext ctx) : KeyAction(ctx) {
 			Combo = new KeyCombo(VirtualKey.S)
 		}
 	};
-
-	public override bool CanInvoke() => this.Context.Editor != null;
 	
-	public override bool Invoke() {
-		if (!this.CanInvoke()) return false;
-		this.Context.Editor!.Cameras.ToggleWorkCameraMode();
-		return true;
-	}
+    // stub action used purely for bindable referencing in WorkCamera.cs; should not override native inputs
+	public override bool Invoke() => false;
 }

--- a/Ktisis/Actions/Handlers/Camera/WorkcamBackAction.cs
+++ b/Ktisis/Actions/Handlers/Camera/WorkcamBackAction.cs
@@ -1,0 +1,28 @@
+using Dalamud.Game.ClientState.Keys;
+
+using Ktisis.Actions.Attributes;
+using Ktisis.Actions.Binds;
+using Ktisis.Actions.Types;
+using Ktisis.Core.Types;
+using Ktisis.Data.Config.Actions;
+
+namespace Ktisis.Actions.Handlers.Camera;
+
+[Action("Camera_Work_Back")]
+public class WorkcamBackAction(IPluginContext ctx) : KeyAction(ctx) {
+	public override KeybindInfo BindInfo { get; } = new() {
+		Trigger = KeybindTrigger.OnDown,
+		Default = new ActionKeybind {
+			Enabled = true,
+			Combo = new KeyCombo(VirtualKey.NO_KEY)
+		}
+	};
+
+	public override bool CanInvoke() => this.Context.Editor != null;
+	
+	public override bool Invoke() {
+		if (!this.CanInvoke()) return false;
+		this.Context.Editor!.Cameras.ToggleWorkCameraMode();
+		return true;
+	}
+}

--- a/Ktisis/Actions/Handlers/Camera/WorkcamDownAction.cs
+++ b/Ktisis/Actions/Handlers/Camera/WorkcamDownAction.cs
@@ -14,7 +14,7 @@ public class WorkcamDownAction(IPluginContext ctx) : KeyAction(ctx) {
 		Trigger = KeybindTrigger.OnDown,
 		Default = new ActionKeybind {
 			Enabled = true,
-			Combo = new KeyCombo(VirtualKey.NO_KEY)
+			Combo = new KeyCombo(VirtualKey.Q)
 		}
 	};
 

--- a/Ktisis/Actions/Handlers/Camera/WorkcamDownAction.cs
+++ b/Ktisis/Actions/Handlers/Camera/WorkcamDownAction.cs
@@ -17,12 +17,7 @@ public class WorkcamDownAction(IPluginContext ctx) : KeyAction(ctx) {
 			Combo = new KeyCombo(VirtualKey.Q)
 		}
 	};
-
-	public override bool CanInvoke() => this.Context.Editor != null;
 	
-	public override bool Invoke() {
-		if (!this.CanInvoke()) return false;
-		this.Context.Editor!.Cameras.ToggleWorkCameraMode();
-		return true;
-	}
+    // stub action used purely for bindable referencing in WorkCamera.cs; should not override native inputs
+	public override bool Invoke() => false;
 }

--- a/Ktisis/Actions/Handlers/Camera/WorkcamDownAction.cs
+++ b/Ktisis/Actions/Handlers/Camera/WorkcamDownAction.cs
@@ -1,0 +1,28 @@
+using Dalamud.Game.ClientState.Keys;
+
+using Ktisis.Actions.Attributes;
+using Ktisis.Actions.Binds;
+using Ktisis.Actions.Types;
+using Ktisis.Core.Types;
+using Ktisis.Data.Config.Actions;
+
+namespace Ktisis.Actions.Handlers.Camera;
+
+[Action("Camera_Work_Down")]
+public class WorkcamDownAction(IPluginContext ctx) : KeyAction(ctx) {
+	public override KeybindInfo BindInfo { get; } = new() {
+		Trigger = KeybindTrigger.OnDown,
+		Default = new ActionKeybind {
+			Enabled = true,
+			Combo = new KeyCombo(VirtualKey.NO_KEY)
+		}
+	};
+
+	public override bool CanInvoke() => this.Context.Editor != null;
+	
+	public override bool Invoke() {
+		if (!this.CanInvoke()) return false;
+		this.Context.Editor!.Cameras.ToggleWorkCameraMode();
+		return true;
+	}
+}

--- a/Ktisis/Actions/Handlers/Camera/WorkcamFastAction.cs
+++ b/Ktisis/Actions/Handlers/Camera/WorkcamFastAction.cs
@@ -1,0 +1,28 @@
+using Dalamud.Game.ClientState.Keys;
+
+using Ktisis.Actions.Attributes;
+using Ktisis.Actions.Binds;
+using Ktisis.Actions.Types;
+using Ktisis.Core.Types;
+using Ktisis.Data.Config.Actions;
+
+namespace Ktisis.Actions.Handlers.Camera;
+
+[Action("Camera_Work_Fast")]
+public class WorkcamFastAction(IPluginContext ctx) : KeyAction(ctx) {
+	public override KeybindInfo BindInfo { get; } = new() {
+		Trigger = KeybindTrigger.OnDown,
+		Default = new ActionKeybind {
+			Enabled = true,
+			Combo = new KeyCombo(VirtualKey.NO_KEY)
+		}
+	};
+
+	public override bool CanInvoke() => this.Context.Editor != null;
+	
+	public override bool Invoke() {
+		if (!this.CanInvoke()) return false;
+		this.Context.Editor!.Cameras.ToggleWorkCameraMode();
+		return true;
+	}
+}

--- a/Ktisis/Actions/Handlers/Camera/WorkcamFastAction.cs
+++ b/Ktisis/Actions/Handlers/Camera/WorkcamFastAction.cs
@@ -11,18 +11,13 @@ namespace Ktisis.Actions.Handlers.Camera;
 [Action("Camera_Work_Fast")]
 public class WorkcamFastAction(IPluginContext ctx) : KeyAction(ctx) {
 	public override KeybindInfo BindInfo { get; } = new() {
-		Trigger = KeybindTrigger.OnDown,
+		Trigger = KeybindTrigger.OnHeld,
 		Default = new ActionKeybind {
 			Enabled = true,
 			Combo = new KeyCombo(VirtualKey.SHIFT)
 		}
 	};
-
-	public override bool CanInvoke() => this.Context.Editor != null;
 	
-	public override bool Invoke() {
-		if (!this.CanInvoke()) return false;
-		this.Context.Editor!.Cameras.ToggleWorkCameraMode();
-		return true;
-	}
+    // stub action used purely for bindable referencing in WorkCamera.cs; should not override native inputs
+	public override bool Invoke() => false;
 }

--- a/Ktisis/Actions/Handlers/Camera/WorkcamFastAction.cs
+++ b/Ktisis/Actions/Handlers/Camera/WorkcamFastAction.cs
@@ -14,7 +14,7 @@ public class WorkcamFastAction(IPluginContext ctx) : KeyAction(ctx) {
 		Trigger = KeybindTrigger.OnDown,
 		Default = new ActionKeybind {
 			Enabled = true,
-			Combo = new KeyCombo(VirtualKey.NO_KEY)
+			Combo = new KeyCombo(VirtualKey.SHIFT)
 		}
 	};
 

--- a/Ktisis/Actions/Handlers/Camera/WorkcamForwardAction.cs
+++ b/Ktisis/Actions/Handlers/Camera/WorkcamForwardAction.cs
@@ -18,11 +18,6 @@ public class WorkcamForwardAction(IPluginContext ctx) : KeyAction(ctx) {
 		}
 	};
 
-	public override bool CanInvoke() => this.Context.Editor != null;
-	
-	public override bool Invoke() {
-		if (!this.CanInvoke()) return false;
-		this.Context.Editor!.Cameras.ToggleWorkCameraMode();
-		return true;
-	}
+    // stub action used purely for bindable referencing in WorkCamera.cs; should not override native inputs
+	public override bool Invoke() => false;
 }

--- a/Ktisis/Actions/Handlers/Camera/WorkcamForwardAction.cs
+++ b/Ktisis/Actions/Handlers/Camera/WorkcamForwardAction.cs
@@ -14,7 +14,7 @@ public class WorkcamForwardAction(IPluginContext ctx) : KeyAction(ctx) {
 		Trigger = KeybindTrigger.OnDown,
 		Default = new ActionKeybind {
 			Enabled = true,
-			Combo = new KeyCombo(VirtualKey.NO_KEY)
+			Combo = new KeyCombo(VirtualKey.W)
 		}
 	};
 

--- a/Ktisis/Actions/Handlers/Camera/WorkcamForwardAction.cs
+++ b/Ktisis/Actions/Handlers/Camera/WorkcamForwardAction.cs
@@ -1,0 +1,28 @@
+using Dalamud.Game.ClientState.Keys;
+
+using Ktisis.Actions.Attributes;
+using Ktisis.Actions.Binds;
+using Ktisis.Actions.Types;
+using Ktisis.Core.Types;
+using Ktisis.Data.Config.Actions;
+
+namespace Ktisis.Actions.Handlers.Camera;
+
+[Action("Camera_Work_Forward")]
+public class WorkcamForwardAction(IPluginContext ctx) : KeyAction(ctx) {
+	public override KeybindInfo BindInfo { get; } = new() {
+		Trigger = KeybindTrigger.OnDown,
+		Default = new ActionKeybind {
+			Enabled = true,
+			Combo = new KeyCombo(VirtualKey.NO_KEY)
+		}
+	};
+
+	public override bool CanInvoke() => this.Context.Editor != null;
+	
+	public override bool Invoke() {
+		if (!this.CanInvoke()) return false;
+		this.Context.Editor!.Cameras.ToggleWorkCameraMode();
+		return true;
+	}
+}

--- a/Ktisis/Actions/Handlers/Camera/WorkcamLeftAction.cs
+++ b/Ktisis/Actions/Handlers/Camera/WorkcamLeftAction.cs
@@ -17,12 +17,7 @@ public class WorkcamLeftAction(IPluginContext ctx) : KeyAction(ctx) {
 			Combo = new KeyCombo(VirtualKey.A)
 		}
 	};
-
-	public override bool CanInvoke() => this.Context.Editor != null;
 	
-	public override bool Invoke() {
-		if (!this.CanInvoke()) return false;
-		this.Context.Editor!.Cameras.ToggleWorkCameraMode();
-		return true;
-	}
+    // stub action used purely for bindable referencing in WorkCamera.cs; should not override native inputs
+	public override bool Invoke() => false;
 }

--- a/Ktisis/Actions/Handlers/Camera/WorkcamLeftAction.cs
+++ b/Ktisis/Actions/Handlers/Camera/WorkcamLeftAction.cs
@@ -1,0 +1,28 @@
+using Dalamud.Game.ClientState.Keys;
+
+using Ktisis.Actions.Attributes;
+using Ktisis.Actions.Binds;
+using Ktisis.Actions.Types;
+using Ktisis.Core.Types;
+using Ktisis.Data.Config.Actions;
+
+namespace Ktisis.Actions.Handlers.Camera;
+
+[Action("Camera_Work_Left")]
+public class WorkcamLeftAction(IPluginContext ctx) : KeyAction(ctx) {
+	public override KeybindInfo BindInfo { get; } = new() {
+		Trigger = KeybindTrigger.OnDown,
+		Default = new ActionKeybind {
+			Enabled = true,
+			Combo = new KeyCombo(VirtualKey.NO_KEY)
+		}
+	};
+
+	public override bool CanInvoke() => this.Context.Editor != null;
+	
+	public override bool Invoke() {
+		if (!this.CanInvoke()) return false;
+		this.Context.Editor!.Cameras.ToggleWorkCameraMode();
+		return true;
+	}
+}

--- a/Ktisis/Actions/Handlers/Camera/WorkcamLeftAction.cs
+++ b/Ktisis/Actions/Handlers/Camera/WorkcamLeftAction.cs
@@ -14,7 +14,7 @@ public class WorkcamLeftAction(IPluginContext ctx) : KeyAction(ctx) {
 		Trigger = KeybindTrigger.OnDown,
 		Default = new ActionKeybind {
 			Enabled = true,
-			Combo = new KeyCombo(VirtualKey.NO_KEY)
+			Combo = new KeyCombo(VirtualKey.A)
 		}
 	};
 

--- a/Ktisis/Actions/Handlers/Camera/WorkcamRightAction.cs
+++ b/Ktisis/Actions/Handlers/Camera/WorkcamRightAction.cs
@@ -17,12 +17,7 @@ public class WorkcamRightAction(IPluginContext ctx) : KeyAction(ctx) {
 			Combo = new KeyCombo(VirtualKey.D)
 		}
 	};
-
-	public override bool CanInvoke() => this.Context.Editor != null;
 	
-	public override bool Invoke() {
-		if (!this.CanInvoke()) return false;
-		this.Context.Editor!.Cameras.ToggleWorkCameraMode();
-		return true;
-	}
+    // stub action used purely for bindable referencing in WorkCamera.cs; should not override native inputs
+	public override bool Invoke() => false;
 }

--- a/Ktisis/Actions/Handlers/Camera/WorkcamRightAction.cs
+++ b/Ktisis/Actions/Handlers/Camera/WorkcamRightAction.cs
@@ -14,7 +14,7 @@ public class WorkcamRightAction(IPluginContext ctx) : KeyAction(ctx) {
 		Trigger = KeybindTrigger.OnDown,
 		Default = new ActionKeybind {
 			Enabled = true,
-			Combo = new KeyCombo(VirtualKey.NO_KEY)
+			Combo = new KeyCombo(VirtualKey.D)
 		}
 	};
 

--- a/Ktisis/Actions/Handlers/Camera/WorkcamRightAction.cs
+++ b/Ktisis/Actions/Handlers/Camera/WorkcamRightAction.cs
@@ -1,0 +1,28 @@
+using Dalamud.Game.ClientState.Keys;
+
+using Ktisis.Actions.Attributes;
+using Ktisis.Actions.Binds;
+using Ktisis.Actions.Types;
+using Ktisis.Core.Types;
+using Ktisis.Data.Config.Actions;
+
+namespace Ktisis.Actions.Handlers.Camera;
+
+[Action("Camera_Work_Right")]
+public class WorkcamRightAction(IPluginContext ctx) : KeyAction(ctx) {
+	public override KeybindInfo BindInfo { get; } = new() {
+		Trigger = KeybindTrigger.OnDown,
+		Default = new ActionKeybind {
+			Enabled = true,
+			Combo = new KeyCombo(VirtualKey.NO_KEY)
+		}
+	};
+
+	public override bool CanInvoke() => this.Context.Editor != null;
+	
+	public override bool Invoke() {
+		if (!this.CanInvoke()) return false;
+		this.Context.Editor!.Cameras.ToggleWorkCameraMode();
+		return true;
+	}
+}

--- a/Ktisis/Actions/Handlers/Camera/WorkcamSlowAction.cs
+++ b/Ktisis/Actions/Handlers/Camera/WorkcamSlowAction.cs
@@ -14,7 +14,7 @@ public class WorkcamSlowAction(IPluginContext ctx) : KeyAction(ctx) {
 		Trigger = KeybindTrigger.OnDown,
 		Default = new ActionKeybind {
 			Enabled = true,
-			Combo = new KeyCombo(VirtualKey.NO_KEY)
+			Combo = new KeyCombo(VirtualKey.CONTROL)
 		}
 	};
 

--- a/Ktisis/Actions/Handlers/Camera/WorkcamSlowAction.cs
+++ b/Ktisis/Actions/Handlers/Camera/WorkcamSlowAction.cs
@@ -11,18 +11,13 @@ namespace Ktisis.Actions.Handlers.Camera;
 [Action("Camera_Work_Slow")]
 public class WorkcamSlowAction(IPluginContext ctx) : KeyAction(ctx) {
 	public override KeybindInfo BindInfo { get; } = new() {
-		Trigger = KeybindTrigger.OnDown,
+		Trigger = KeybindTrigger.OnHeld,
 		Default = new ActionKeybind {
 			Enabled = true,
 			Combo = new KeyCombo(VirtualKey.CONTROL)
 		}
 	};
-
-	public override bool CanInvoke() => this.Context.Editor != null;
 	
-	public override bool Invoke() {
-		if (!this.CanInvoke()) return false;
-		this.Context.Editor!.Cameras.ToggleWorkCameraMode();
-		return true;
-	}
+    // stub action used purely for bindable referencing in WorkCamera.cs; should not override native inputs
+	public override bool Invoke() => false;
 }

--- a/Ktisis/Actions/Handlers/Camera/WorkcamSlowAction.cs
+++ b/Ktisis/Actions/Handlers/Camera/WorkcamSlowAction.cs
@@ -1,0 +1,28 @@
+using Dalamud.Game.ClientState.Keys;
+
+using Ktisis.Actions.Attributes;
+using Ktisis.Actions.Binds;
+using Ktisis.Actions.Types;
+using Ktisis.Core.Types;
+using Ktisis.Data.Config.Actions;
+
+namespace Ktisis.Actions.Handlers.Camera;
+
+[Action("Camera_Work_Slow")]
+public class WorkcamSlowAction(IPluginContext ctx) : KeyAction(ctx) {
+	public override KeybindInfo BindInfo { get; } = new() {
+		Trigger = KeybindTrigger.OnDown,
+		Default = new ActionKeybind {
+			Enabled = true,
+			Combo = new KeyCombo(VirtualKey.NO_KEY)
+		}
+	};
+
+	public override bool CanInvoke() => this.Context.Editor != null;
+	
+	public override bool Invoke() {
+		if (!this.CanInvoke()) return false;
+		this.Context.Editor!.Cameras.ToggleWorkCameraMode();
+		return true;
+	}
+}

--- a/Ktisis/Actions/Handlers/Camera/WorkcamUpAction.cs
+++ b/Ktisis/Actions/Handlers/Camera/WorkcamUpAction.cs
@@ -1,0 +1,28 @@
+using Dalamud.Game.ClientState.Keys;
+
+using Ktisis.Actions.Attributes;
+using Ktisis.Actions.Binds;
+using Ktisis.Actions.Types;
+using Ktisis.Core.Types;
+using Ktisis.Data.Config.Actions;
+
+namespace Ktisis.Actions.Handlers.Camera;
+
+[Action("Camera_Work_Up")]
+public class WorkcamUpAction(IPluginContext ctx) : KeyAction(ctx) {
+	public override KeybindInfo BindInfo { get; } = new() {
+		Trigger = KeybindTrigger.OnDown,
+		Default = new ActionKeybind {
+			Enabled = true,
+			Combo = new KeyCombo(VirtualKey.NO_KEY)
+		}
+	};
+
+	public override bool CanInvoke() => this.Context.Editor != null;
+	
+	public override bool Invoke() {
+		if (!this.CanInvoke()) return false;
+		this.Context.Editor!.Cameras.ToggleWorkCameraMode();
+		return true;
+	}
+}

--- a/Ktisis/Actions/Handlers/Camera/WorkcamUpAction.cs
+++ b/Ktisis/Actions/Handlers/Camera/WorkcamUpAction.cs
@@ -14,7 +14,7 @@ public class WorkcamUpAction(IPluginContext ctx) : KeyAction(ctx) {
 		Trigger = KeybindTrigger.OnDown,
 		Default = new ActionKeybind {
 			Enabled = true,
-			Combo = new KeyCombo(VirtualKey.NO_KEY)
+			Combo = new KeyCombo(VirtualKey.SPACE)
 		}
 	};
 

--- a/Ktisis/Actions/Handlers/Camera/WorkcamUpAction.cs
+++ b/Ktisis/Actions/Handlers/Camera/WorkcamUpAction.cs
@@ -17,12 +17,7 @@ public class WorkcamUpAction(IPluginContext ctx) : KeyAction(ctx) {
 			Combo = new KeyCombo(VirtualKey.SPACE)
 		}
 	};
-
-	public override bool CanInvoke() => this.Context.Editor != null;
 	
-	public override bool Invoke() {
-		if (!this.CanInvoke()) return false;
-		this.Context.Editor!.Cameras.ToggleWorkCameraMode();
-		return true;
-	}
+    // stub action used purely for bindable referencing in WorkCamera.cs; should not override native inputs
+	public override bool Invoke() => false;
 }

--- a/Ktisis/Data/Config/Sections/EditorConfig.cs
+++ b/Ktisis/Data/Config/Sections/EditorConfig.cs
@@ -16,6 +16,13 @@ public class EditorConfig {
 	public bool UseLegacyWindowBehavior = false;
 	public bool UseLegacyPoseViewTabs = false;
 	public bool UseLegacyLightEditor = false;
+
+	// work camera config
+	public float WorkcamMoveSpeed = 0.1f;
+	public float WorkcamFastMulti = 2.5f;
+	public float WorkcamSlowMulti = 0.25f;
+	public float WorkcamVertMulti = 1f;
+	public float WorkcamSens = 0.215f;
 	
 	public Dictionary<EntityType, EntityDisplay> Display = EntityDisplay.GetDefaults();
 	

--- a/Ktisis/Editor/Camera/CameraManager.cs
+++ b/Ktisis/Editor/Camera/CameraManager.cs
@@ -76,7 +76,7 @@ public class CameraManager : ICameraManager {
 	}
 
 	private void SetupWorkCamera() {
-		this.WorkCamera ??= new WorkCamera(this) { Name = "Work Camera" };
+		this.WorkCamera ??= new WorkCamera(this, this._context) { Name = "Work Camera" };
 		if (!this.CopyOntoCamera(this.WorkCamera))
 			throw new Exception("Failed to setup work camera.");
 	}

--- a/Ktisis/Editor/Camera/Types/WorkCamera.cs
+++ b/Ktisis/Editor/Camera/Types/WorkCamera.cs
@@ -61,27 +61,27 @@ public class WorkCamera : KtisisCamera {
 
 	private unsafe void UpdateKeyboard(KeyboardDeviceData* keyData, bool leftHeld, bool rightHeld) {
 		this.MoveSpeed = this.DefaultSpeed;
-		if (keyData->IsKeyDown(VirtualKey.SHIFT)) // FreecamFast
+		if (keyData->IsKeyDown(this._ctx.Config.Keybinds.Keybinds["Camera_Work_Fast"].Combo.Key)) // FreecamFast
 			this.MoveSpeed *= this._ctx.Config.Editor.WorkcamFastMulti; // FreecamShiftMulti
-		else if (keyData->IsKeyDown(VirtualKey.CONTROL)) // FreecamSlow
+		else if (keyData->IsKeyDown(this._ctx.Config.Keybinds.Keybinds["Camera_Work_Slow"].Combo.Key)) // FreecamSlow
 			this.MoveSpeed *= this._ctx.Config.Editor.WorkcamSlowMulti; // FreecamCtrlMulti
 
 		var vFwb = 0;
 		var bothHeld = leftHeld && rightHeld;
-		if (IsKeyDown(keyData, VirtualKey.W) || bothHeld) vFwb -= 1; // Forward
-		if (IsKeyDown(keyData, VirtualKey.S)) vFwb += 1; // Back
+		if (IsKeyDown(keyData, this._ctx.Config.Keybinds.Keybinds["Camera_Work_Forward"].Combo.Key) || bothHeld) vFwb -= 1; // Forward
+		if (IsKeyDown(keyData, this._ctx.Config.Keybinds.Keybinds["Camera_Work_Back"].Combo.Key)) vFwb += 1; // Back
 
 		var vLr = 0;
-		if (IsKeyDown(keyData, VirtualKey.A)) vLr -= 1; // Left
-		if (IsKeyDown(keyData, VirtualKey.D)) vLr += 1; // Right
+		if (IsKeyDown(keyData, this._ctx.Config.Keybinds.Keybinds["Camera_Work_Left"].Combo.Key)) vLr -= 1; // Left
+		if (IsKeyDown(keyData, this._ctx.Config.Keybinds.Keybinds["Camera_Work_Right"].Combo.Key)) vLr += 1; // Right
 
 		this.Velocity.X = vFwb * MathF.Sin(this.Rotation.X) * MathF.Cos(this.Rotation.Y) + (vLr * MathF.Cos(this.Rotation.X));
 		this.Velocity.Y = vFwb * MathF.Sin(this.Rotation.Y);
 		this.Velocity.Z = vFwb * MathF.Cos(this.Rotation.X) * MathF.Cos(this.Rotation.Y) + (-vLr * MathF.Sin(this.Rotation.X));
 
-		if (IsKeyDown(keyData, VirtualKey.SPACE))
+		if (IsKeyDown(keyData, this._ctx.Config.Keybinds.Keybinds["Camera_Work_Up"].Combo.Key))
 			this.Velocity.Y += this._ctx.Config.Editor.WorkcamVertMulti; // FreecamUpDownMulti
-		if (IsKeyDown(keyData, VirtualKey.Q))
+		if (IsKeyDown(keyData, this._ctx.Config.Keybinds.Keybinds["Camera_Work_Down"].Combo.Key))
 			this.Velocity.Y -= this._ctx.Config.Editor.WorkcamVertMulti;
 	}
 

--- a/Ktisis/Interface/Components/Config/ActionKeybindEditor.cs
+++ b/Ktisis/Interface/Components/Config/ActionKeybindEditor.cs
@@ -48,6 +48,7 @@ public class ActionKeybindEditor {
 	private readonly static Vector2 CellPadding = new(8, 8);
 
 	public void Draw() {
+		// TODO: allow sorting that isnt alphabetical
 		using var pad = ImRaii.PushStyle(ImGuiStyleVar.WindowPadding, Vector2.Zero);
 		using var frame = ImRaii.Child("##CfgStyleFrame", ImGui.GetContentRegionAvail(), false);
 		if (!frame.Success) return;

--- a/Ktisis/Interface/Windows/ConfigWindow.cs
+++ b/Ktisis/Interface/Windows/ConfigWindow.cs
@@ -145,6 +145,14 @@ public class ConfigWindow : KtisisWindow {
 		ImGui.Checkbox(this.Locale.Translate("config.workspace.legacyWindows"), ref this.Config.Editor.UseLegacyWindowBehavior);
 		ImGui.Checkbox(this.Locale.Translate("config.workspace.legacyPoseTabs"), ref this.Config.Editor.UseLegacyPoseViewTabs);
 		ImGui.Checkbox(this.Locale.Translate("config.workspace.legacyLightEditor"), ref this.Config.Editor.UseLegacyLightEditor);
+		
+		ImGui.Spacing();
+
+		ImGui.DragFloat(this.Locale.Translate("config.workspace.workcam.speed"), ref this.Config.Editor.WorkcamMoveSpeed, 0.001f, 0.0f, 100.0f);
+		ImGui.DragFloat(this.Locale.Translate("config.workspace.workcam.fastMulti"), ref this.Config.Editor.WorkcamFastMulti, 0.001f, 0.0f, 100.0f);
+		ImGui.DragFloat(this.Locale.Translate("config.workspace.workcam.slowMulti"), ref this.Config.Editor.WorkcamSlowMulti, 0.001f, 0.0f, 100.0f);
+		ImGui.DragFloat(this.Locale.Translate("config.workspace.workcam.vertMulti"), ref this.Config.Editor.WorkcamVertMulti, 0.001f, 0.0f, 100.0f);
+		ImGui.DragFloat(this.Locale.Translate("config.workspace.workcam.sens"), ref this.Config.Editor.WorkcamSens, 0.001f, 0.0f, 100.0f);
 	}
 	
 	// Input

--- a/Ktisis/Localization/Data/en_US.json
+++ b/Ktisis/Localization/Data/en_US.json
@@ -258,7 +258,14 @@
 			"editOnSelect": "Toggle object editor when selecting",
 			"legacyWindows": "Prefer legacy window behavior",
 			"legacyPoseTabs": "Prefer legacy pose view tabs",
-			"legacyLightEditor": "Prefer legacy light editor"
+			"legacyLightEditor": "Prefer legacy light editor",
+			"workcam": {
+				"speed": "Work camera speed",
+				"fastMulti": "Work camera fast-multiplier",
+				"slowMulti": "Work camera slow-multiplier",
+				"vertMulti": "Work camera up/down speed multiplier",
+				"sens": "Work camera mouse sensitivity"
+			}
 		},
 		"input": {
 			"title": "Input",

--- a/Ktisis/Localization/Data/en_US.json
+++ b/Ktisis/Localization/Data/en_US.json
@@ -22,7 +22,15 @@
 		"Gizmo_SetUniversalMode": "Switch to universal mode",
 		"Camera_SetNext": "Switch to next camera",
 		"Camera_SetPrevious": "Switch to previous camera",
-		"Camera_Work_Toggle": "Toggle work camera"
+		"Camera_Work_Toggle": "Toggle work camera",
+		"Camera_Work_Forward": "Work camera forward",
+		"Camera_Work_Left": "Work camera left",
+		"Camera_Work_Back": "Work camera backward",
+		"Camera_Work_Right": "Work camera right",
+		"Camera_Work_Up": "Work camera up",
+		"Camera_Work_Down": "Work camera down",
+		"Camera_Work_Fast": "Work camera fast-speed modifier",
+		"Camera_Work_Slow": "Work camera slow-speed modifier"
 	},
 	
 	"actors": {


### PR DESCRIPTION
### changes
- Actions/Handlers/Camera
  - added new action file for each bindable workcamera control; these could probably be consolidated to just one since theyre stubs
  - each action has no invoke value; instead, we can just reference the default or user-set KeyCombo for WorkCamera.cs' original input processing
- EditorConfig.cs
  - adds WorkCamera speed/sensitivity values (speed, fast/slow/vert multi, mouse sens)
  - added to ConfigWindow.cs under Workspace
- WorkCamera.cs
  - replaced hardcoded keybinds (WASD, Shift+Ctrl, etc) with references to each workcamera action's defined KeyCombo
  - replaced hardcoded speeds and multipliers with references to config's editable work camera sliders

### todo
- config window input listing is a bit bulky/hard to make sense of in alphabetical order; would be nice to be able to group related settings (e.g. workcam forward/back/left/right & workcam up/down) together in the sort
- consolidate 8 input files to just one containing the action stubs

<img width="829" height="395" alt="image" src="https://github.com/user-attachments/assets/93b78a16-e9b9-41ea-8986-507154ae567b" />
<img width="821" height="506" alt="image" src="https://github.com/user-attachments/assets/5a477797-9cfe-42dd-9c70-15d7a177fb9d" />
